### PR TITLE
Be more aggressive with updating cloud config

### DIFF
--- a/templates/ec2_cloud.groovy
+++ b/templates/ec2_cloud.groovy
@@ -114,8 +114,9 @@ def cloudList = instance.clouds
 
 // avoid duplicate cloud provider on the cloud list
 // pulled from https://gist.github.com/xbeta/e5edcf239fcdbe3f1672
-if ( ! cloudList.getByName("ec2-{{ cloud.name }}") ) {
-    cloudList.add(new_cloud)
+if (cloudList.getByName("ec2-{{ cloud.name }}") ) {
+    cloudList.remove(cloudList.getByName("ec2-{{ cloud.name }}"))
 }
+cloudList.add(new_cloud)
 
 {% endfor %}


### PR DESCRIPTION
I was a little conservative earlier with not trying to clobber existing
cloud configuration. This was a mistake since certain parameters of cloud
config have been changing rapidly during testing. This change makes it so
if there is a cloud config with the same name as another one, it will always
clobber on jenkins reboot.