### PR TITLE
Adds support for Github Branch Source plugin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,17 +1,14 @@
 ---
+jenkins_home: /var/lib/jenkins
 jenkins_deploy_css_url: https://jenkins-contrib-themes.github.io/jenkins-material-theme/dist/material-blue.css
 jenkins_deploy_js_url: ""
 
 jenkins_deploy_config_master_exe: 0
 jenkins_deploy_config_disableusage_stats: true
 
-jenkins_deploy_groovy: []
-#  - github_auth
-#  - github_auth_strategy
-
-# These github auth settings wont be utilized unless
-#   the groovy scripts listed above are deployed
-#   ( the data below is bogus and specifically use your own ids here)
+#
+# Utilize GitHub Oauth for authorization and permissions
+###############################################################
 jenkins_deploy_gh_oauth: {}
 #  url: https://github.com
 #  api_url: https://api.github.com
@@ -27,6 +24,28 @@ jenkins_deploy_gh_oauth_strategy: {}
 #  github_webhook: true
 #  authread_all: true
 
+#
+# Utilize GitHub Org to populate pipeline jobs
+###############################################################
+jenkins_deploy_gh_folder: []
+#  - job_name: "GitHub Scanner"
+#    owner: mygithuborg
+#    scan_cred_id: gh_token_id
+#    health_recursive: false
+#    scan_pattern: repo_name (OR leave off for all in org)
+#    origin_branch: true
+#    origin_branch_pr: true
+#    origin_pr_merge: false
+#    origin_pr_head: false
+#    fork_pr_merge: false
+#    fork_pr_head: false
+#    prune_dead_branch: true
+#    prune_days: 0
+#    prune_number: 0
+
+#
+# Jenkins credentials
+###############################################################
 jenkins_deploy_ssh_files: []
 # - keyname: mykey
 #   username: root
@@ -48,6 +67,9 @@ jenkins_deploy_userpass_creds: []
 
 jenkins_deploy_plugin_files: []
 
+#
+# Jenkins EC2 cloud builders
+###############################################################
 jenkins_deploy_ec2_clouds: []
 #  - name: MyEC2Cloud
 #    credential_id: awscredid
@@ -67,6 +89,9 @@ jenkins_deploy_ec2_clouds: []
 #        remoteadmin: jenkins
 #        connectsshprocess: true
 
+#
+# nginx reverse proxy settings used in testing
+###############################################################
 jenkins_nginx_usercontent: |
   location /userContent {
     root {{ jenkins_home }}/;

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,12 @@ jenkins_deploy_aws_keys: []
 #   secret: ASDJADKJAKDLSAJDLKAJDLSAJDLAS
 #   desc: "Jenkins AWS user for EC2 building"
 
+jenkins_deploy_userpass_creds: []
+# - id: usernamepass
+#   username: myuser
+#   password: password
+#   description: "My user credentials"
+
 jenkins_deploy_plugin_files: []
 
 jenkins_deploy_ec2_clouds: []

--- a/playbook.yml
+++ b/playbook.yml
@@ -30,6 +30,7 @@
       - ec2
       - github
       - github-oauth
+      - github-branch-source
       - simple-theme-plugin
       - slack
       - ssh-credentials

--- a/playbook.yml
+++ b/playbook.yml
@@ -21,8 +21,8 @@
         - "{{ jenkins_nginx_root }}"
       encrypted:
         - listen 443 ssl
-        - ssl_certificate /etc/ssl/certs/localhost.pem
-        - ssl_certificate_key /etc/ssl/private/localhost-key.pem
+        - ssl_certificate /etc/ssl/certs/{{ ansible_fqdn }}.pem
+        - ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}-key.pem
         - "{{ jenkins_nginx_usercontent }}"
         - "{{ jenkins_nginx_root }}"
     jenkins_plugins:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,11 +1,23 @@
 ---
 - name: Drop any groovy scripts
   template:
-    src: "{{ item }}"
+    src: "{{ item }}.groovy"
     dest: "{{ jenkins_home }}/init.groovy.d/"
-  with_fileglob:
-    - templates/*groovy
+  when: item != 'skip'
+  register: result_groovy
+  with_items:
+    - "{{ 'github_folder' if jenkins_deploy_gh_folder else 'skip' }}"
+    - general_config
+    - creds
+    - "{{ 'ec2_cloud' if jenkins_deploy_ec2_clouds else 'skip' }}"
+    - "{{ 'github_auth' if jenkins_deploy_gh_oauth else 'skip' }}"
   notify: restart jenkins
+
+- name: Remove github folder lock if a new groovy script dropped
+  file:
+    path: "{{ jenkins_home }}/..disable-init_gh_folder"
+    state: absent
+  when: result_groovy.results[0].changed and jenkins_deploy_gh_folder
 
 - name: Ensure jenkins creds sshdirectory exists
   file:

--- a/tasks/groovy.yml
+++ b/tasks/groovy.yml
@@ -1,7 +1,0 @@
-
-- name: Drop any groovy scripts
-  template:
-    src: "{{ item }}.groovy.j2"
-    dest: "{{ jenkins_home }}/init.groovy.d/{{ item }}.groovy"
-  with_items: "{{ jenkins_deploy_groovy }}"
-  notify: restart jenkins

--- a/templates/creds.groovy
+++ b/templates/creds.groovy
@@ -38,3 +38,15 @@ aws_cred = new AWSCredentialsImpl(
 )
 store.addCredentials(domain, aws_cred)
 {% endfor %}
+
+{% for key in jenkins_deploy_userpass_creds %}
+// USERNAME + PASSWORD CREDS
+userandpass = new UsernamePasswordCredentialsImpl(
+    CredentialsScope.GLOBAL,
+    "{{ key.id }}",
+    "{{ key.description | default('') }}",
+    "{{ key.username | default('') }}",
+    "{{ key.password }}"
+)
+store.addCredentials(domain, userandpass)
+{% endfor %}

--- a/templates/github_folder.groovy
+++ b/templates/github_folder.groovy
@@ -1,0 +1,108 @@
+// Adapted from https://github.com/beedemo/pse-cje-sa/quickstart/init_22_github_org_project.groovy
+import hudson.model.*;
+import jenkins.model.*;
+
+import hudson.security.ACL;
+import jenkins.branch.OrganizationFolder;
+import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.SCMSourceOwners;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
+
+import java.util.logging.Logger
+
+Logger logger = Logger.getLogger("guthub_folder.groovy")
+
+def j = Jenkins.instance
+
+File disableScript = new File(j.rootDir, ".disable-init_gh_folder")
+if (disableScript.exists()) {
+    logger.info("DISABLED github folder script")
+    return
+}
+
+{% for gh_org in jenkins_deploy_gh_folder %}
+    println "--> creating {{ gh_org.job_name }}"
+    def jobConfigXml = """
+	<jenkins.branch.OrganizationFolder plugin="branch-api@2.0.6">
+	  <actions/>
+	  <description></description>
+	  <properties>
+		<com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty plugin="cloudbees-folder@5.17">
+		  <domainCredentialsMap class="hudson.util.CopyOnWriteMap\$Hash">
+			<entry>
+			  <com.cloudbees.plugins.credentials.domains.Domain plugin="credentials@2.1.11">
+				<specifications/>
+			  </com.cloudbees.plugins.credentials.domains.Domain>
+			  <java.util.concurrent.CopyOnWriteArrayList/>
+			</entry>
+		  </domainCredentialsMap>
+		</com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+		<org.jenkinsci.plugins.pipeline.modeldefinition.config.FolderConfig plugin="pipeline-model-definition@1.0.2">
+		  <dockerLabel></dockerLabel>
+		  <registry plugin="docker-commons@1.6"/>
+		</org.jenkinsci.plugins.pipeline.modeldefinition.config.FolderConfig>
+		<jenkins.branch.NoTriggerOrganizationFolderProperty>
+		  <branches>{{ gh_org.no_branches | default(".*") }}</branches>
+		</jenkins.branch.NoTriggerOrganizationFolderProperty>
+	  </properties>
+	  <folderViews class="jenkins.branch.OrganizationFolderViewHolder">
+		<owner reference="../.."/>
+	  </folderViews>
+	  <healthMetrics>
+		<com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric plugin="cloudbees-folder@5.17">
+		  <nonRecursive>{{ gh_org.health_recursive }}</nonRecursive>
+		</com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+	  </healthMetrics>
+	  <icon class="jenkins.branch.MetadataActionFolderIcon">
+		<owner class="jenkins.branch.OrganizationFolder" reference="../.."/>
+	  </icon>
+	  <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@5.17">
+		<pruneDeadBranches>{{ gh_org.prune_dead_branch | default(true) }}</pruneDeadBranches>
+		<daysToKeep>{{ gh_org.prune_days | default(0) }}</daysToKeep>
+		<numToKeep>{{ gh_org.prune_number | default(0) }}</numToKeep>
+	  </orphanedItemStrategy>
+	  <triggers>
+		<com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger plugin="cloudbees-folder@5.17">
+		  <spec>H H * * *</spec>
+		  <interval>86400000</interval>
+		</com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger>
+	  </triggers>
+	  <navigators>
+		<org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator plugin="github-branch-source@2.0.3">
+		  <repoOwner>{{ gh_org.owner }}</repoOwner>
+		  <scanCredentialsId>{{ gh_org.scan_cred_id }}</scanCredentialsId>
+		  <checkoutCredentialsId>{{ gh_org.checkout_cred_id | default("SAME") }}</checkoutCredentialsId>
+		  <pattern>{{ gh_org.scan_pattern | default(".*") }}</pattern>
+		  <buildOriginBranch>{{ gh_org.origin_branch }}</buildOriginBranch>
+		  <buildOriginBranchWithPR>{{ gh_org.origin_branch_pr }}</buildOriginBranchWithPR>
+		  <buildOriginPRMerge>{{ gh_org.origin_pr_merge | default(false) }}</buildOriginPRMerge>
+		  <buildOriginPRHead>{{ gh_org.origin_pr_head | default(false) }}</buildOriginPRHead>
+		  <buildForkPRMerge>{{ gh_org.fork_pr_merge | default(false) }}</buildForkPRMerge>
+		  <buildForkPRHead>{{ gh_org.fork_pr_head | default(false) }}</buildForkPRHead>
+		</org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator>
+	  </navigators>
+	  <projectFactories>
+		<org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectFactory plugin="workflow-multibranch@2.12"/>
+	  </projectFactories>
+	</jenkins.branch.OrganizationFolder>
+    """
+
+    job = j.createProjectFromXML("{{ gh_org.job_name }}", new ByteArrayInputStream(jobConfigXml.getBytes("UTF-8")));
+    job.save()
+    //the following will actually kickoff the initial scanning
+    ACL.impersonate(ACL.SYSTEM, new Runnable() {
+                    @Override public void run() {
+                        for (final SCMSourceOwner owner : SCMSourceOwners.all()) {
+                            if (owner instanceof OrganizationFolder) {
+                                OrganizationFolder orgFolder = (OrganizationFolder) owner;
+                                for (GitHubSCMNavigator navigator : orgFolder.getNavigators().getAll(GitHubSCMNavigator.class)) {
+                                    orgFolder.scheduleBuild();
+                                }
+                            }
+                        }
+                    }
+                });
+    logger.info("created {{ gh_org.job_name }}")
+{% endfor %}
+ //create marker file to disable scripts from running twice
+ disableScript.createNewFile()


### PR DESCRIPTION
This was really hacky and was lovingly lifted from an example XML groovy
conversion script I found in Github (left a comment reference in the template). Its
not really idempotent right now but it does the job of allowing us to record the
important details in code and works without intervention on first launch. Subsequent
modifications will require manual intervention (deleting existing job) but other than that
its good to go. 

Ummm how do you really test this? Well you'll have to accurately fill out two default
vars:

* `jenkins_deploy_gh_folder` AND
* `jenkins_deploy_userpass_creds`

Of particular note the `jenkins_deploy_userpass_creds`, you can call the id whatever you
want it just has to match up with the same id name you drop under `scan_cred_id` field in
the `jenkins_deploy_gh_folder` dict. You also dont need a username for the cred dict, just
the id, password, and recommended to always put a description (not sure if that last one is
really required but I always put it in).