### PR TITLE
Update deploy dependency to java 8

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,6 @@ galaxy_info:
     - CI
 
 dependencies:
-  - geerlingguy.jenkins
+  - role: geerlingguy.jenkins
+    java_packages:
+      - openjdk-8-jdk


### PR DESCRIPTION
Since Jenkins 2.55, java 8 is now required. I made some upstream changes
to geerlingguy.java which should hopefully get merged through this PR
https://github.com/geerlingguy/ansible-role-java/pull/47 :fingers-crossed: