### PR TITLE
Add support for Slack and secrettext credential type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,32 +20,110 @@ Role Variables
 --------------
 
 ```yaml
-## Modify below entries to customize UI
+---
+jenkins_home: /var/lib/jenkins
 jenkins_deploy_css_url: https://jenkins-contrib-themes.github.io/jenkins-material-theme/dist/material-blue.css
 jenkins_deploy_js_url: ""
 
-# Drop a groovy script in templates and then activate it here
-jenkins_deploy_groovy: []
+jenkins_deploy_config_master_exe: 0
+jenkins_deploy_config_disableusage_stats: true
 
-# These github auth settings wont be utilized unless
-#   the groovy scripts github_auth and github_auth_strategy are deployed
-#   ( the data below is bogus. Use your own ids here)
-jenkins_deploy_gh_oauth:
-  url: https://github.com
-  api_url: https://api.github.com
-  client_id: 12314124412
-  secret_id: 23424324324
-  scope: "read:org"
+#
+# Utilize GitHub Oauth for authorization and permissions
+###############################################################
+jenkins_deploy_gh_oauth: {}
+#  url: https://github.com
+#  api_url: https://api.github.com
+#  client_id: 12314124412
+#  secret_id: 23424324324
+#  scope: "read:org"
 
-jenkins_deploy_gh_oauth_strategy:
-  admins:
-    - msheiny
-  organizations:
-    - organization
-  github_webhook: true
-  authread_all: true
+jenkins_deploy_gh_oauth_strategy: {}
+#  admins:
+#    - msheiny
+#  organizations:
+#    - organization
+#  github_webhook: true
+#  authread_all: true
 
-# Nginx recomended settings
+#
+# Utilize GitHub Org to populate pipeline jobs
+###############################################################
+jenkins_deploy_gh_folder: []
+#  - job_name: "GitHub Scanner"
+#    owner: mygithuborg
+#    scan_cred_id: gh_token_id
+#    health_recursive: false
+#    scan_pattern: repo_name (OR leave off for all in org)
+#    origin_branch: true
+#    origin_branch_pr: true
+#    origin_pr_merge: false
+#    origin_pr_head: false
+#    fork_pr_merge: false
+#    fork_pr_head: false
+#    prune_dead_branch: true
+#    prune_days: 0
+#    prune_number: 0
+
+#
+# Jenkins credentials
+###############################################################
+jenkins_deploy_ssh_files: []
+# - keyname: mykey
+#   username: root
+#   privkey: Asdjadsoijadjasdlkajdljadjs
+#   passphrase: yay
+#   description: 'This is my key for service x'
+
+jenkins_deploy_aws_keys: []
+# - id: jenkinsawskey
+#   key: ASdoKJDASDOAJD
+#   secret: ASDJADKJAKDLSAJDLKAJDLSAJDLAS
+#   desc: "Jenkins AWS user for EC2 building"
+
+jenkins_deploy_userpass_creds: []
+# - id: usernamepass
+#   username: myuser
+#   password: password
+#   description: "My user credentials"
+
+jenkins_deploy_secret_creds: []
+#  - id: slack-token
+#    desc: "Slack credential token"
+#    secret: "124908124908124/12489012840912/124890124021408"
+
+jenkins_slack_settings: {}
+#  domain: mydomain
+#  cred_id: slack-token
+#  room: "#fav-room"
+
+jenkins_deploy_plugin_files: []
+
+#
+# Jenkins EC2 cloud builders
+###############################################################
+jenkins_deploy_ec2_clouds: []
+#  - name: MyEC2Cloud
+#    credential_id: awscredid
+#    instance_cap: 5
+#    region: us-east-1
+#    private_key: "{{ ssh_private_key }}"
+#    workers:
+#      - ami_id: asdadaisdo
+#        description: UbuntuWorker
+#        security_groups: SSHSG
+#        remote_fs_root: /home/jenkins/workspace
+#        ebs_optimized: false
+#        instance_type: t2.small
+#        labels: aws-builders
+#        mode: normal # NORMAL = Utilize as much as possible, EXCLUSIVE = only for tied jobs
+#        executors: 1
+#        remoteadmin: jenkins
+#        connectsshprocess: true
+
+#
+# nginx reverse proxy settings used in testing
+###############################################################
 jenkins_nginx_usercontent: |
   location /userContent {
     root {{ jenkins_home }}/;
@@ -56,10 +134,12 @@ jenkins_nginx_usercontent: |
     sendfile on;
   }
 
+jenkins_master_pkgs: []
+
 jenkins_nginx_root: |
   location / {
     sendfile off;
-    proxy_pass         http://127.0.0.1:{{ jenkins_http_port }};
+    proxy_pass         http://127.0.0.1:8080;
     proxy_redirect     default;
 
     proxy_set_header   Host              $host;
@@ -82,6 +162,14 @@ jenkins_nginx_root: |
     proxy_busy_buffers_size    64k;
     proxy_temp_file_write_size 64k;
   }
+
+jenkins_static_configs:
+  # Disable legacy insecure CLI over remoting option
+  - src: disable.remote.cli.xml
+    dest: "{{ jenkins_home }}/jenkins.CLI.xml"
+  # Enable slave to master security system
+  - content: "false"
+    dest: "{{ jenkins_home }}/secrets/slave-to-master-security-kill-switch"
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,11 @@ jenkins_deploy_userpass_creds: []
 #   password: password
 #   description: "My user credentials"
 
+jenkins_deploy_secret_creds: []
+#  - id: slack-token
+#    desc: "Slack credential token"
+#    secret: "124908124908124/12489012840912/124890124021408"
+
 jenkins_slack_settings: {}
 #  domain: mydomain
 #  cred_id: slack-token

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,8 @@ jenkins_nginx_usercontent: |
     sendfile on;
   }
 
+jenkins_master_pkgs: []
+
 jenkins_nginx_root: |
   location / {
     sendfile off;

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,11 @@ jenkins_deploy_userpass_creds: []
 #   password: password
 #   description: "My user credentials"
 
+jenkins_slack_settings: {}
+#  domain: mydomain
+#  cred_id: slack-token
+#  room: "#fav-room"
+
 jenkins_deploy_plugin_files: []
 
 #

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,6 +11,7 @@
     - creds
     - "{{ 'ec2_cloud' if jenkins_deploy_ec2_clouds else 'skip' }}"
     - "{{ 'github_auth' if jenkins_deploy_gh_oauth else 'skip' }}"
+    - "{{ 'slack' if jenkins_slack_settings else 'skip' }}"
   notify: restart jenkins
 
 - name: Remove github folder lock if a new groovy script dropped

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install additional package on jenkins master
+  package:
+    name: "{{ item }}"
+  with_items: "{{ jenkins_master_pkgs }}"
+
 - include: tweaks.yml
 
 - include: config.yml

--- a/templates/creds.groovy
+++ b/templates/creds.groovy
@@ -3,8 +3,10 @@ import com.cloudbees.plugins.credentials.*
 import com.cloudbees.plugins.credentials.common.*
 import com.cloudbees.plugins.credentials.domains.*
 import com.cloudbees.plugins.credentials.impl.*
+import org.jenkinsci.plugins.plaincredentials.impl.*
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.*
 import hudson.plugins.sshslaves.*;
+import hudson.util.Secret
 {% if jenkins_deploy_aws_keys -%}
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl
 {% endif %}
@@ -49,4 +51,15 @@ userandpass = new UsernamePasswordCredentialsImpl(
     "{{ key.password }}"
 )
 store.addCredentials(domain, userandpass)
+{% endfor %}
+
+{% for key in jenkins_deploy_secret_creds %}
+// Secret Text
+secretText = new StringCredentialsImpl(
+    CredentialsScope.GLOBAL,
+    "{{ key.id }}",
+    "{{ key.desc }}",
+    Secret.fromString("{{ key.secret }}"))
+
+store.addCredentials(domain, secretText)
 {% endfor %}

--- a/templates/slack.groovy
+++ b/templates/slack.groovy
@@ -1,0 +1,13 @@
+import jenkins.model.*
+import jenkins.plugins.slack.*
+
+jenkins = Jenkins.getInstance()
+
+slack_cfg = jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl)
+
+slack_cfg.teamDomain = "{{ jenkins_slack_settings.domain }}"
+slack_cfg.tokenCredentialId = "{{ jenkins_slack_settings.cred_id}}"
+slack_cfg.room = "{{ jenkins_slack_settings.room }}"
+slack_cfg.baseUrl = "{{jenkins_slack_settings.base_url|default('https://hooks.slack.com/services/')}}"
+slack_cfg.sendAs = "{{ jenkins_slack_settings.send_as|default('jenkins') }}"
+slack_cfg.save()


### PR DESCRIPTION
Fairly straight-forward optional settings that are configured through role variables.
* Slack support - requires the `slack` jenkins plugin be installed
* secrettext - is a type of credential storage that you can reference through many other jobs/settings (including via slack config)
* added misc package install support -- really straight-forward task to also install additional sys packages required for jenkins on the master node