### PR TITLE
Adds `google-compute-engine` support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,6 +125,8 @@ jenkins_deploy_gce_clouds: []
 #        disk_size: 20
 #        mode: exclusive
 
+google_compute_api_root: https://www.googleapis.com/compute/v1/projects
+
 #
 # nginx reverse proxy settings used in testing
 ###############################################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -183,7 +183,7 @@ jenkins_deploy_config_disablecrsf: true
 
 # This is upstream jenkins options we over-ride to provide additional CSRF
 # settings see https://wiki.jenkins.io/display/JENKINS/CSRF+Protection
-jenkins_java_options: "-Djenkins.install.runSetupWizard=false -Dhudson.security.csrf.requestfield=Jenkins-Crumb -Dhudson.remoting.ClassFilter=GCENetConf"
+jenkins_java_options: "-Djenkins.install.runSetupWizard=false -Dhudson.security.csrf.requestfield=Jenkins-Crumb"
 
 # Location of a user provided DSL template file to copy.
 # Requires that the jenkins job-dsl plugin is installed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,10 @@ jenkins_slack_settings: {}
 
 jenkins_deploy_plugin_files: []
 
+jenkins_deploy_gce_keys: []
+#  - json_contents: "{{ service_key_json_contents }}"
+#    project_id: "project_name"
+
 #
 # Jenkins EC2 cloud builders
 ###############################################################
@@ -98,6 +102,28 @@ jenkins_deploy_ec2_clouds: []
 #        executors: 1
 #        remoteadmin: jenkins
 #        connectsshprocess: true
+
+
+#
+# Jenkins Google Compute Engine cloud builders
+#   *relies on 'google-compute-engine' installed as a plugin
+###############################################################
+jenkins_deploy_gce_clouds: []
+#  - name: MyGCECloud
+#    project: project-name
+#    credential_id: project-name
+#    instance_cap: 5
+#    region: us-west-1
+#    workers:
+#      - prefix: ci-
+#        description: CI builder
+#        region: us-west-1
+#        zone: us-west1-d
+#        type: n1-standard-1
+#        image_name: rhel-7-v20180522
+#        image_project: rhel-cloud
+#        disk_size: 20
+#        mode: exclusive
 
 #
 # nginx reverse proxy settings used in testing
@@ -157,7 +183,7 @@ jenkins_deploy_config_disablecrsf: true
 
 # This is upstream jenkins options we over-ride to provide additional CSRF
 # settings see https://wiki.jenkins.io/display/JENKINS/CSRF+Protection
-jenkins_java_options: "-Djenkins.install.runSetupWizard=false -Dhudson.security.csrf.requestfield=Jenkins-Crumb"
+jenkins_java_options: "-Djenkins.install.runSetupWizard=false -Dhudson.security.csrf.requestfield=Jenkins-Crumb -Dhudson.remoting.ClassFilter=GCENetConf"
 
 # Location of a user provided DSL template file to copy.
 # Requires that the jenkins job-dsl plugin is installed

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,5 @@ galaxy_info:
     - CI
 
 dependencies:
-  - geerlingguy.jenkins
+  - role: geerlingguy.jenkins
+    jenkins_java_options: "-Djenkins.install.runSetupWizard=false -Dhudson.security.csrf.requestfield=Jenkins-Crumb"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -10,6 +10,7 @@
     - general_config
     - creds
     - "{{ 'ec2_cloud' if jenkins_deploy_ec2_clouds else 'skip' }}"
+    - "{{ 'gce_cloud' if jenkins_deploy_gce_clouds else 'skip' }}"
     - "{{ 'github_auth' if jenkins_deploy_gh_oauth else 'skip' }}"
     - "{{ 'slack' if jenkins_slack_settings else 'skip' }}"
     - "{{ jenkins_deploy_seed_groovy if jenkins_deploy_seed_template != '' else 'skip' }}"
@@ -44,13 +45,16 @@
   notify: restart jenkins
   with_items: "{{ jenkins_static_configs }}"
 
-- name: Ensure jenkins creds sshdirectory exists
+- name: Ensure jenkins creds directories exist
   file:
     state: directory
-    path: "{{ jenkins_home }}/.ssh/"
+    path: "{{ jenkins_home }}/{{ item }}/"
     owner: jenkins
     group: jenkins
     mode: 0700
+  with_items:
+    - .ssh
+    - .gce
 
 - name: Copy over any ssh config files
   copy:
@@ -62,3 +66,13 @@
   no_log: true
   register: register_copyssh
   with_items: "{{ jenkins_deploy_ssh_files }}"
+
+- name: Copy over contents of Google Compute JSON keys
+  copy:
+    content: "{{ item.json_contents }}"
+    dest: "{{ jenkins_home }}/.gce/{{ item.project_id }}.json"
+    owner: jenkins
+    group: jenkins
+    mode: 0700
+  no_log: true
+  with_items: "{{ jenkins_deploy_gce_keys }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_items: "{{ jenkins_master_pkgs }}"
 
 - import_tasks: tweaks.yml
+  tags: xml
 
 - import_tasks: config.yml
+  tags: config
 
 - import_tasks: plugins.yml

--- a/templates/ec2_cloud.groovy
+++ b/templates/ec2_cloud.groovy
@@ -66,7 +66,7 @@ def worker_ami = new SlaveTemplate(
   // List<EC2Tag> tags
   ec2_tags,
   // String idleTerminationMinutes
-  '30',
+  '{{ worker.idle_terminate|default(30) }}',
   // boolean usePrivateDnsName
   {{ worker.usePrivateDns|default(false)|lower() }},
   // String instanceCapStr

--- a/templates/ec2_cloud.groovy
+++ b/templates/ec2_cloud.groovy
@@ -19,12 +19,12 @@ def worker_amis = []
 
 {% for worker in cloud.workers %}
 
-def ec2_tags = []
+def ec2_tags_{{loop.index}} = []
 {% for key, value in worker.ec2_tags|default([]) %}
-ec2_tags.add(new EC2Tag("{{ key }}", "{{ value }}"))
+ec2_tags_{{loop.index}}.add(new EC2Tag("{{ key }}", "{{ value }}"))
 {% endfor %}
 
-def worker_ami = new SlaveTemplate(
+def worker_ami_{{loop.index}} = new SlaveTemplate(
   // String ami
   "{{ worker.ami_id }}",
   // String zone
@@ -64,7 +64,7 @@ def worker_ami = new SlaveTemplate(
   // String subnetId
   "{{ worker.subnet_id | default('') }}",
   // List<EC2Tag> tags
-  ec2_tags,
+  ec2_tags_{{loop.index}},
   // String idleTerminationMinutes
   '{{ worker.idle_terminate|default(30) }}',
   // boolean usePrivateDnsName
@@ -91,7 +91,7 @@ def worker_ami = new SlaveTemplate(
   {{ worker.connectpublicip | default(false)| lower() }},
 )
 
-worker_amis.add(worker_ami)
+worker_amis.add(worker_ami_{{loop.index}})
 {% endfor %}
 
 

--- a/templates/gce_cloud.groovy
+++ b/templates/gce_cloud.groovy
@@ -1,6 +1,7 @@
 import hudson.model.*
 import jenkins.model.*
 import com.google.jenkins.plugins.computeengine.AcceleratorConfiguration
+import com.google.jenkins.plugins.computeengine.AutofilledNetworkConfiguration
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud
 import com.google.jenkins.plugins.computeengine.InstanceConfiguration
 import com.google.jenkins.plugins.computeengine.NetworkConfiguration
@@ -13,16 +14,8 @@ def worker_instances = []
 
 {% for worker in cloud.workers %}
 
-// I'm doing something here which Jenkins security doesnt like and had to whitelist
-// Ideally I'd like to find a proper work-around
-// See - https://jenkins.io/blog/2018/03/15/jep-200-lts/
-class GCENetConf extends NetworkConfiguration {
-    public GCENetConf(String network, String subnetwork) {
-        super(network, subnetwork)
-    }
-}
 
-def network_conf = new GCENetConf(
+def network_conf = new AutofilledNetworkConfiguration(
     // network
     "{{ worker.network|default('default') }}",
     // subnetwork

--- a/templates/gce_cloud.groovy
+++ b/templates/gce_cloud.groovy
@@ -7,19 +7,20 @@ import com.google.jenkins.plugins.computeengine.InstanceConfiguration
 import com.google.jenkins.plugins.computeengine.NetworkConfiguration
 
 def instance = Jenkins.getInstance()
-
 {% for cloud in jenkins_deploy_gce_clouds %}
 
 def worker_instances = []
 
 {% for worker in cloud.workers %}
 
+{% set API_ROOT = google_compute_api_root + '/' + cloud.project %}
+{% set API_ZONE_ROOT = API_ROOT + '/zones/' + worker.zone %}
 
 def network_conf = new AutofilledNetworkConfiguration(
     // network
-    "{{ worker.network|default('default') }}",
+    "{{ API_ROOT }}/global/networks/default",
     // subnetwork
-    "{{ worker.subnetwork|default('default') }}"
+    "default"
 )
 
 // Dont need to support this now personally
@@ -31,11 +32,11 @@ def worker_gce = new InstanceConfiguration(
   // instance prefix name
   "{{ worker.prefix|default('jenkins-') }}",
   // region
-  "{{ worker.region }}",
+  "{{ API_ROOT }}/regions/{{ worker.region }}",
   // zone
-  "{{ worker.zone }}",
+  "{{ API_ZONE_ROOT }}",
   // machine type
-  "{{ worker.type }}",
+  "{{ API_ZONE_ROOT }}/machineTypes/{{ worker.type }}",
   // number of executors
   "{{ worker.executors|default(1) }}",
   // startupscript
@@ -47,11 +48,11 @@ def worker_gce = new InstanceConfiguration(
   // description
   "{{ worker.description }}",
   // bootdisk type
-  "{{ worker.disktype | default('pd-standard') }}",
+  "{{ API_ZONE_ROOT }}/diskTypes/{{ worker.disktype | default('pd-standard') }}",
   // bootdisk autodelete
   {{ worker.autodelete|default(true)|bool|lower }},
   // String source image name
-  "{{ worker.image_name }}",
+  "{{ API_ROOT }}/global/images/{{ worker.image_name }}",
   // String source image project
   "{{ worker.image_project }}",
   // Bootdisk GB size

--- a/templates/gce_cloud.groovy
+++ b/templates/gce_cloud.groovy
@@ -103,8 +103,8 @@ def cloudList = instance.clouds
 
 // avoid duplicate cloud provider on the cloud list
 // pulled from https://gist.github.com/xbeta/e5edcf239fcdbe3f1672
-if (cloudList.getByName("{{ cloud.name }}") ) {
-    cloudList.remove(cloudList.getByName("{{ cloud.name }}"))
+if (cloudList.getByName("gce-{{ cloud.name }}") ) {
+    cloudList.remove(cloudList.getByName("gce-{{ cloud.name }}"))
 }
 cloudList.add(new_cloud)
 

--- a/templates/gce_cloud.groovy
+++ b/templates/gce_cloud.groovy
@@ -1,0 +1,117 @@
+import hudson.model.*
+import jenkins.model.*
+import com.google.jenkins.plugins.computeengine.AcceleratorConfiguration
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration
+import com.google.jenkins.plugins.computeengine.NetworkConfiguration
+
+def instance = Jenkins.getInstance()
+
+{% for cloud in jenkins_deploy_gce_clouds %}
+
+def worker_instances = []
+
+{% for worker in cloud.workers %}
+
+// I'm doing something here which Jenkins security doesnt like and had to whitelist
+// Ideally I'd like to find a proper work-around
+// See - https://jenkins.io/blog/2018/03/15/jep-200-lts/
+class GCENetConf extends NetworkConfiguration {
+    public GCENetConf(String network, String subnetwork) {
+        super(network, subnetwork)
+    }
+}
+
+def network_conf = new GCENetConf(
+    // network
+    "{{ worker.network|default('default') }}",
+    // subnetwork
+    "{{ worker.subnetwork|default('default') }}"
+)
+
+// Dont need to support this now personally
+// It's up to the internetz to implement
+AcceleratorConfiguration gpu_type = null
+
+// https://github.com/jenkinsci/google-compute-engine-plugin/blob/master/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+def worker_gce = new InstanceConfiguration(
+  // instance prefix name
+  "{{ worker.prefix|default('jenkins-') }}",
+  // region
+  "{{ worker.region }}",
+  // zone
+  "{{ worker.zone }}",
+  // machine type
+  "{{ worker.type }}",
+  // number of executors
+  "{{ worker.executors|default(1) }}",
+  // startupscript
+  """{{ worker.startup_script|default('') }}""",
+  // preemptible VM ? (cheaper but can be terminated at will)
+  {{ worker.preemptible|default(false)|bool|lower }},
+  // labels (for jenkins internal usage)
+  "{{ worker.labels|default([])|join(" ") }}",
+  // description
+  "{{ worker.description }}",
+  // bootdisk type
+  "{{ worker.disktype | default('pd-standard') }}",
+  // bootdisk autodelete
+  {{ worker.autodelete|default(true)|bool|lower }},
+  // String source image name
+  "{{ worker.image_name }}",
+  // String source image project
+  "{{ worker.image_project }}",
+  // Bootdisk GB size
+  "{{ worker.disk_size|default(10)|int }}",
+  // network configuration
+  network_conf,
+  // external address ?
+  {{ worker.ext_addr|default(true)|bool|lower }},
+  // use internal external address for communication?
+  // this will work even if you activate an external address
+  {{ worker.int_addr|default(false)|bool|lower }},
+  // network tags
+  "{{ worker.net_tags|default([])|join(" ") }}",
+  // service account (email) that will be associated with the node
+  "{{ worker.service_email | default('') }}",
+  // retention time in minutes
+  "{{ worker.retention |default(30) }}",
+  // launch timeout in seconds
+  // (The number of seconds a new node has to provision and come online. )
+  "{{ worker.launchtimeout |default(300) }}",
+  // Node.Mode mode (NORMAL or EXCLUSIVE)
+  // NORMAL == as much as possible
+  // EXCLUSIVE == only for jobs that match this builder label type
+  Node.Mode.{{ worker.mode | default('NORMAL')| upper() }},
+  // GPU type
+  gpu_type,
+  // Run as user
+  "{{ worker.runasuser | default('jenkins') }}"
+)
+worker_instances.add(worker_gce)
+{% endfor %}
+
+
+def new_cloud = new ComputeEngineCloud(
+  // String cloudName
+  "{{ cloud.name }}",
+  // project id name
+  "{{ cloud.project }}",
+  // String credentialsId
+  "{{ cloud.credential_id }}",
+  // max number of instances to launch
+  "{{ cloud.instance_max|default('1') }}",
+  // List of instance configurations
+  worker_instances
+)
+
+def cloudList = instance.clouds
+
+// avoid duplicate cloud provider on the cloud list
+// pulled from https://gist.github.com/xbeta/e5edcf239fcdbe3f1672
+if (cloudList.getByName("{{ cloud.name }}") ) {
+    cloudList.remove(cloudList.getByName("{{ cloud.name }}"))
+}
+cloudList.add(new_cloud)
+
+{% endfor %}


### PR DESCRIPTION
This PR allows abstraction of the official [google-compute-engine plugin](https://plugins.jenkins.io/google-compute-engine) including the following with-out GUI interaction:

* Adding an oauth json token to the jenkins credential store
* Adding a google cloud config instance 

~There's a potential security issue I had to whitelist past to get my custom groovy workin' (see the commit details) but otherwise~ things were fairly straight-forward (just a :hankey: load of java source code diggin' )