### PR TITLE
Work-around for SECURITY-440 credential bind issue

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ansible
+ansible<2.5
 docker
 molecule
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,73 +4,75 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-ansible-lint==3.4.19      # via molecule
-ansible==2.4.2.0
-anyconfig==0.9.1          # via molecule
+ansible-lint==3.4.23      # via molecule
+ansible==2.4.6.0
+anyconfig==0.9.4          # via molecule
 arrow==0.12.1             # via jinja2-time
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0             # via pytest
-backports.functools-lru-cache==1.4  # via arrow
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
+backports.functools-lru-cache==1.5  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
 bcrypt==3.1.4             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
-certifi==2018.1.18        # via requests
-cffi==1.11.4              # via bcrypt, cryptography, pynacl
+cerberus==1.2             # via molecule
+certifi==2018.4.16        # via requests
+cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
-click-completion==0.2.1   # via molecule
-click==6.7                # via click-completion, cookiecutter, git-url-parse, molecule, pip-tools, python-gilt, safety
-colorama==0.3.7           # via molecule, python-gilt
+click-completion==0.3.1   # via molecule
+click==6.7                # via click-completion, cookiecutter, molecule, pip-tools, python-gilt, safety
+colorama==0.3.9           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
-cookiecutter==1.5.1       # via molecule
-cryptography==2.1.4       # via ansible, paramiko
-docker-pycreds==0.2.1     # via docker
-docker==2.7.0
-dparse==0.2.1             # via safety
+cookiecutter==1.6.0       # via molecule
+cryptography==2.3         # via ansible, paramiko
+docker-pycreds==0.3.0     # via docker
+docker==3.4.1
+dparse==0.4.1             # via safety
 enum34==1.1.6             # via cryptography, flake8
 fasteners==0.14.1         # via python-gilt
 first==2.0.1              # via pip-tools
-flake8==3.3.0             # via molecule
+flake8==3.5.0             # via molecule
 funcsigs==1.0.2           # via pytest
 future==0.16.0            # via cookiecutter
-git-url-parse==1.0.2      # via python-gilt
-idna==2.6                 # via cryptography, requests
-ipaddress==1.0.19         # via cryptography, docker
+git-url-parse==1.1.0      # via python-gilt
+idna==2.7                 # via cryptography, requests
+ipaddress==1.0.22         # via cryptography, docker
 jinja2-time==0.2.0        # via cookiecutter
-jinja2==2.9.6             # via ansible, click-completion, cookiecutter, jinja2-time, molecule
+jinja2==2.10              # via ansible, click-completion, cookiecutter, jinja2-time, molecule
 markupsafe==1.0           # via jinja2
-marshmallow==2.13.5       # via molecule
 mccabe==0.6.1             # via flake8
-molecule==2.7.0
-monotonic==1.4            # via fasteners
-packaging==16.8           # via dparse, safety
-paramiko==2.4.0           # via ansible
-pathspec==0.5.5           # via yamllint
-pbr==3.0.1                # via git-url-parse, molecule, python-gilt
-pexpect==4.2.1            # via molecule
-pip-tools==1.11.0
+molecule==2.16.0
+monotonic==1.5            # via fasteners
+more-itertools==4.2.0     # via pytest
+packaging==17.1           # via dparse, safety
+paramiko==2.4.1           # via ansible
+pathspec==0.5.6           # via yamllint
+pbr==4.0.4                # via git-url-parse, molecule, python-gilt
+pexpect==4.6.0            # via molecule
+pip-tools==2.0.2
 pluggy==0.6.0             # via pytest
 poyo==0.4.1               # via cookiecutter
-psutil==5.2.2             # via molecule
-ptyprocess==0.5.2         # via pexpect
-py==1.5.2                 # via pytest
-pyasn1==0.4.2             # via paramiko
+psutil==5.4.6             # via molecule
+ptyprocess==0.6.0         # via pexpect
+py==1.5.4                 # via pytest
+pyasn1==0.4.4             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
-pyflakes==1.5.0           # via flake8
+pyflakes==1.6.0           # via flake8
 pynacl==1.2.1             # via paramiko
 pyparsing==2.2.0          # via packaging
-pytest==3.4.0             # via testinfra
-python-dateutil==2.6.1    # via arrow
-python-gilt==1.1.0        # via molecule
+pytest==3.6.3             # via testinfra
+python-dateutil==2.7.3    # via arrow
+python-gilt==1.2.1        # via molecule
 pyyaml==3.12              # via ansible, ansible-lint, dparse, molecule, python-gilt, yamllint
-requests==2.18.4          # via docker, safety
-safety==1.6.1
+requests==2.19.1          # via cookiecutter, docker, safety
+safety==1.8.3
 sh==1.12.14               # via molecule, python-gilt
-six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, dparse, fasteners, git-url-parse, packaging, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
-tabulate==0.7.7           # via molecule
-testinfra==1.7.1          # via molecule
+six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, dparse, fasteners, molecule, more-itertools, packaging, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
+tabulate==0.8.2           # via molecule
+testinfra==1.14.0         # via molecule
 tree-format==0.1.2        # via molecule
-urllib3==1.22             # via requests
-websocket-client==0.46.0  # via docker
+urllib3==1.23             # via requests
+websocket-client==0.48.0  # via docker
 whichcraft==0.4.1         # via cookiecutter
-yamllint==1.8.1           # via molecule
+yamllint==1.11.1          # via molecule

--- a/templates/creds.groovy
+++ b/templates/creds.groovy
@@ -37,11 +37,12 @@ def update_or_add_creds(Credentials user_provided_creds) {
 
 {% for key in jenkins_deploy_ssh_files %}
 // SSH KEYS
+String sshKey = new File("{{jenkins_home}}/.ssh/{{key.keyname}}").text
 privateKey = new BasicSSHUserPrivateKey(
     CredentialsScope.GLOBAL,
     "{{ key.keyname }}",
     "{{ key.username }}",
-    new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource("{{jenkins_home}}/.ssh/{{key.keyname}}"),
+    new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(sshKey),
     "{{ key.passphrase | default('') }}",
     "{{ key.description | default('') }}"
 )


### PR DESCRIPTION
So technically, the "fix" I did here doesn't really mitigate against the
issue reported - I'm just working around the deprecated method. What
does this mean? 

Well, be sure to follow jenkins best-practices here:
* lock-down privileges of users, 
* do not run nodes on the jenkins master, and 
* whitelist groovy scripts.

https://jenkins.io/security/advisory/2018-06-25/#SECURITY-440